### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/Test453/84ff2f19-89e7-4a4c-a114-1ce848a2aa04/f65cd676-32d9-4e75-9aaf-10b8dae6406c/_apis/work/boardbadge/3ce2976d-bdbb-4641-b94c-badac3647db4)](https://dev.azure.com/Test453/84ff2f19-89e7-4a4c-a114-1ce848a2aa04/_boards/board/t/f65cd676-32d9-4e75-9aaf-10b8dae6406c/Microsoft.RequirementCategory)
 # Test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Test453/84ff2f19-89e7-4a4c-a114-1ce848a2aa04/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.